### PR TITLE
Carousel debug

### DIFF
--- a/client/app/components/product-carousel/index.jsx
+++ b/client/app/components/product-carousel/index.jsx
@@ -23,7 +23,7 @@ class Carousel extends React.Component {
       quickview: false,
     };
     this.productList = React.createRef();
-    this.productCarousel = React.createRef();
+    this.outerContainer = React.createRef();
     this.nextSlide = this.nextSlide.bind(this);
     this.previousSlide = this.previousSlide.bind(this);
     this.openQuickView = this.openQuickView.bind(this);
@@ -37,11 +37,12 @@ class Carousel extends React.Component {
 
   calculatePosition(currentIndex) {
     let index = currentIndex;
+    const container = this.outerContainer.current;
     const list = this.productList.current.firstChild;
     if (list === null || list.childNodes.length === 0) {
       return null;
     }
-    const containerWidth = list.offsetWidth;
+    const containerWidth = container.offsetWidth;
     // We do not want 8 hard codded here
     const cardWidth = list.childNodes[index].offsetWidth + 8;
     const totalWidth = list.childNodes.length * cardWidth;
@@ -112,7 +113,7 @@ class Carousel extends React.Component {
       quickview,
     } = this.state;
     return (
-      <OuterContainer>
+      <OuterContainer ref={this.outerContainer}>
         <Button
           side="left"
           title="Previous Slide"

--- a/client/app/components/product-carousel/index.jsx
+++ b/client/app/components/product-carousel/index.jsx
@@ -10,7 +10,8 @@ const OuterContainer = style.div`
 
 const InnerContainer = style.div`
   padding: 12px 4px;
-  overflow: hidden;`;
+  overflow: hidden;
+  box-sizing: border-box;`;
 
 class Carousel extends React.Component {
   constructor(props) {
@@ -23,7 +24,6 @@ class Carousel extends React.Component {
       quickview: false,
     };
     this.productList = React.createRef();
-    this.outerContainer = React.createRef();
     this.nextSlide = this.nextSlide.bind(this);
     this.previousSlide = this.previousSlide.bind(this);
     this.openQuickView = this.openQuickView.bind(this);
@@ -37,7 +37,7 @@ class Carousel extends React.Component {
 
   calculatePosition(currentIndex) {
     let index = currentIndex;
-    const container = this.outerContainer.current;
+    const container = this.productList.current;
     const list = this.productList.current.firstChild;
     if (list === null || list.childNodes.length === 0) {
       return null;
@@ -49,6 +49,7 @@ class Carousel extends React.Component {
     const limit = totalWidth - containerWidth;
     let position = -(index * cardWidth);
     const offset = limit + position;
+    console.log(index, containerWidth, cardWidth, totalWidth, limit, position, offset);
     if (offset < 0) {
       position = -limit;
       index = Math.ceil(limit / cardWidth);
@@ -113,7 +114,7 @@ class Carousel extends React.Component {
       quickview,
     } = this.state;
     return (
-      <OuterContainer ref={this.outerContainer}>
+      <OuterContainer>
         <Button
           side="left"
           title="Previous Slide"

--- a/client/app/components/product-carousel/index.jsx
+++ b/client/app/components/product-carousel/index.jsx
@@ -38,7 +38,7 @@ class Carousel extends React.Component {
   calculatePosition(currentIndex) {
     let index = currentIndex;
     const container = this.productList.current;
-    const list = this.productList.current.firstChild;
+    const list = container.firstChild;
     if (list === null || list.childNodes.length === 0) {
       return null;
     }
@@ -49,7 +49,6 @@ class Carousel extends React.Component {
     const limit = totalWidth - containerWidth;
     let position = -(index * cardWidth);
     const offset = limit + position;
-    console.log(index, containerWidth, cardWidth, totalWidth, limit, position, offset);
     if (offset < 0) {
       position = -limit;
       index = Math.ceil(limit / cardWidth);


### PR DESCRIPTION
Fix bug for carousel positioning while products are in quickview. 

The bug was caused with the wrong assumption that the global styling (which has "box-sizing: border-box;" rule) will replace the default rule ("box-sizing: content-box;") for a "div" element (in this case the "InnerConteriner" component). The implicit rule caused the "offsetWidth" property to return the element width without side padding (4px on each side, in a total of 8px), and the position calc algorithm left the right carousel button exposed because of those extra 8px.